### PR TITLE
Replace serde_cbor with ciborium

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "askar-crypto",
  "askar-storage",
  "async-lock",
+ "ciborium",
  "criterion",
  "env_logger",
  "ffi-support",
@@ -167,7 +168,6 @@ dependencies = [
  "once_cell",
  "rand",
  "serde",
- "serde_cbor",
  "serde_json",
  "zeroize",
 ]
@@ -189,6 +189,7 @@ dependencies = [
  "cbc",
  "chacha20",
  "chacha20poly1305",
+ "ciborium",
  "cipher",
  "criterion",
  "crypto_box",
@@ -206,7 +207,6 @@ dependencies = [
  "rand",
  "serde",
  "serde-json-core",
- "serde_cbor",
  "sha2",
  "subtle",
  "uuid",
@@ -224,6 +224,7 @@ dependencies = [
  "async-stream",
  "bs58",
  "chrono",
+ "ciborium",
  "digest",
  "env_logger",
  "futures-lite",
@@ -237,7 +238,6 @@ dependencies = [
  "rand",
  "rmp-serde",
  "serde",
- "serde_cbor",
  "serde_json",
  "sha2",
  "sqlx",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -552,15 +552,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -744,6 +744,12 @@ checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1238,9 +1244,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2274,16 +2284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9e1ab533c0bc414c34920ec7e5f097101d126ed5eac1a1aac711222e0bbb33"
 dependencies = [
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ sqlite = ["askar-storage/sqlite"]
 
 [dependencies]
 async-lock = "3.0"
+ciborium = "0.2"
 env_logger = { version = "0.10", optional = true }
 ffi-support = { version = "0.4", optional = true }
 jemallocator = { version = "0.5", optional = true }
 log = { version = "0.4", optional = true }
 once_cell = "1.5"
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.11"
 serde_json = "1.0"
 zeroize = "1.5"
 

--- a/askar-crypto/Cargo.toml
+++ b/askar-crypto/Cargo.toml
@@ -33,12 +33,12 @@ std_rng = ["getrandom", "rand/std", "rand/std_rng"]
 
 [dev-dependencies]
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
+ciborium = "0.2"
 criterion = "0.5"
 hex-literal = "0.4"
 serde-json-core = { version = "0.5", default-features = false, features = [
     "std",
 ] }
-serde_cbor = "0.11"
 
 [[bench]]
 harness = false

--- a/askar-crypto/src/alg/aes/mod.rs
+++ b/askar-crypto/src/alg/aes/mod.rs
@@ -297,8 +297,9 @@ mod tests {
         fn test_serialize<T: AesType>() {
             let key = AesKey::<T>::random().unwrap();
             let sk = key.to_secret_bytes().unwrap();
-            let bytes = serde_cbor::to_vec(&key).unwrap();
-            let deser: &[u8] = serde_cbor::from_slice(bytes.as_ref()).unwrap();
+            let mut bytes = alloc::vec::Vec::new();
+            ciborium::into_writer(&key, &mut bytes).unwrap();
+            let deser: alloc::vec::Vec<u8> = ciborium::from_reader(&bytes[..]).unwrap();
             assert_eq!(deser, sk.as_ref());
         }
         test_serialize::<A128Gcm>();

--- a/askar-crypto/src/alg/chacha20.rs
+++ b/askar-crypto/src/alg/chacha20.rs
@@ -268,8 +268,9 @@ mod tests {
         fn test_serialize<T: Chacha20Type>() {
             let key = Chacha20Key::<T>::random().unwrap();
             let sk = key.to_secret_bytes().unwrap();
-            let bytes = serde_cbor::to_vec(&key).unwrap();
-            let deser: &[u8] = serde_cbor::from_slice(bytes.as_ref()).unwrap();
+            let mut bytes = vec![];
+            ciborium::into_writer(&key, &mut bytes).unwrap();
+            let deser: alloc::vec::Vec<u8> = ciborium::from_reader(&bytes[..]).unwrap();
             assert_eq!(deser, sk.as_ref());
         }
         test_serialize::<C20P>();

--- a/askar-storage/Cargo.toml
+++ b/askar-storage/Cargo.toml
@@ -31,6 +31,7 @@ async-lock = "3.0"
 async-stream = "0.3"
 bs58 = "0.5"
 chrono = "0.4"
+ciborium = "0.2"
 digest = "0.10"
 futures-lite = "2.0"
 hex = "0.4"
@@ -41,7 +42,6 @@ once_cell = "1.5"
 percent-encoding = "2.0"
 rmp-serde = { version = "1.1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_cbor = "0.11"
 serde_json = "1.0"
 sha2 = "0.10"
 tokio = { version = "1.5", features = ["rt-multi-thread", "time"] }

--- a/askar-storage/src/migration/mod.rs
+++ b/askar-storage/src/migration/mod.rs
@@ -262,7 +262,7 @@ impl IndySdkToAriesAskarMigration {
         };
 
         let profile_key = match profile_row {
-            Some(profile_row) => serde_cbor::from_slice(&profile_row)
+            Some(profile_row) => ciborium::from_reader(&profile_row[..])
                 .map_err(err_map!(Input, "Invalid cbor encoding for profile_key"))?,
             None => {
                 let pk = ProfileKey::new()?;

--- a/src/kms/entry.rs
+++ b/src/kms/entry.rs
@@ -54,9 +54,11 @@ pub struct KeyParams {
 
 impl KeyParams {
     pub(crate) fn to_bytes(&self) -> Result<SecretBytes, Error> {
-        serde_cbor::to_vec(self)
-            .map(SecretBytes::from)
-            .map_err(|e| err_msg!(Unexpected, "Error serializing key params: {}", e))
+        let mut bytes = Vec::new();
+        ciborium::into_writer(self, &mut bytes)
+            .map_err(|e| err_msg!(Unexpected, "Error serializing key params: {}", e))?;
+
+        Ok(SecretBytes::from(bytes))
     }
 
     pub(crate) fn to_id(&self) -> Result<String, Error> {
@@ -70,7 +72,7 @@ impl KeyParams {
     }
 
     pub(crate) fn from_slice(params: &[u8]) -> Result<KeyParams, Error> {
-        serde_cbor::from_slice(params)
+        ciborium::from_reader(&params[..])
             .map_err(|e| err_msg!(Unexpected, "Error deserializing key params: {}", e))
     }
 }


### PR DESCRIPTION
The crate `serde_cbor` is unmaintained and has not received any updates in the last 3 years. The author of serde_cbor proposes [ciborium](https://crates.io/crates/ciborium) as an alternative.
This PR replaces the dependency on `serde_cbor` with `ciborium`.