### PR TITLE
Update python publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,6 +211,8 @@ jobs:
   build-py:
     name: Build and test Python wrapper
     needs: [build-release]
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     strategy:
       matrix:
@@ -221,15 +223,27 @@ jobs:
           - os: ubuntu-latest
             architecture: linux-aarch64
             plat-name: manylinux2014_aarch64
+            environment:
+              name: pypi
+              url: https://pypi.org/p/aries-askar
           - os: ubuntu-latest
             architecture: linux-x86_64
             plat-name: manylinux2014_x86_64
+            environment:
+              name: pypi
+              url: https://pypi.org/p/aries-askar
           - os: macos-latest
             architecture: darwin-universal
             plat-name: macosx_10_9_universal2 # macosx_10_9_x86_64
+            environment:
+              name: pypi
+              url: https://pypi.org/p/aries-askar
           - os: windows-latest
             architecture: windows-x86_64
             plat-name: win_amd64
+            environment:
+              name: pypi
+              url: https://pypi.org/p/aries-askar
 
     runs-on: ${{ matrix.os }}
 
@@ -294,16 +308,11 @@ jobs:
           auditwheel show wrappers/python/dist/* | tee auditwheel.log
           grep -q manylinux_2_17_ auditwheel.log
 
-      - if: |
-          github.event_name == 'release' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-python-wrapper == 'true')
-        name: Publish
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          twine upload --skip-existing dist/*
-        working-directory: wrappers/python
+      - name: Publish
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-python-wrapper == 'true')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wrappers/python/dist
 
   build-ios:
     name: Build library (iOS)


### PR DESCRIPTION
This should work for the python publish. 

Currently on my forked branch I get:

> ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
>          Invalid API Token: OIDC scoped token is not valid for project          
>          'aries-askar', project-scoped token is not valid for project:          
>          'aries-askar'        

but this is because the github action on my fork isn't in the repo matching aries-askar. It's a lot of work to rename everything to test with a personal pypi project, so I haven't done that.

I'm trying to figure out if can share this `environment` config amongst all the matrixes but I can't find much. 