### PR TITLE
Adjust Pypi publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,8 +211,6 @@ jobs:
   build-py:
     name: Build and test Python wrapper
     needs: [build-release]
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     strategy:
       matrix:
@@ -223,27 +221,15 @@ jobs:
           - os: ubuntu-latest
             architecture: linux-aarch64
             plat-name: manylinux2014_aarch64
-            environment:
-              name: pypi
-              url: https://pypi.org/p/aries-askar
           - os: ubuntu-latest
             architecture: linux-x86_64
             plat-name: manylinux2014_x86_64
-            environment:
-              name: pypi
-              url: https://pypi.org/p/aries-askar
           - os: macos-latest
             architecture: darwin-universal
             plat-name: macosx_10_9_universal2 # macosx_10_9_x86_64
-            environment:
-              name: pypi
-              url: https://pypi.org/p/aries-askar
           - os: windows-latest
             architecture: windows-x86_64
             plat-name: win_amd64
-            environment:
-              name: pypi
-              url: https://pypi.org/p/aries-askar
 
     runs-on: ${{ matrix.os }}
 
@@ -308,8 +294,34 @@ jobs:
           auditwheel show wrappers/python/dist/* | tee auditwheel.log
           grep -q manylinux_2_17_ auditwheel.log
 
-      - name: Publish
+      - name: Upload Built Python Package
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-python-wrapper == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: python_package-${{ matrix.plat-name }}
+          path: wrappers/python/dist
+
+  publish-py:
+    name: Publish Python package
+    needs: [build-py]
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish-python-wrapper == 'true')
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aries-askar
+    
+    steps:
+      - name: Fetch Python package
+        uses: actions/download-artifact@v4
+        with:
+         path: wrappers/python/dist
+         pattern: "python_package-*"
+         merge-multiple: true
+      - run: ls -R wrappers/python/dist
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: wrappers/python/dist


### PR DESCRIPTION
This is a new adjustment to the PyPi publish workflow. The existing method didn't work when trying to publish on mac and windows builds. 

Now it builds and uploads. Then downloads the artifacts separately after all the build steps complete and publishes all the packages together from ubuntu-latest os.