### PR TITLE
Fix race condition during Python library loading

### DIFF
--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -5,9 +5,8 @@ try:
 except ImportError:
     import json
 
+from functools import lru_cache
 from typing import Optional, Sequence, Union
-
-from cached_property import cached_property
 
 from . import bindings
 from .bindings import (
@@ -32,22 +31,26 @@ class Entry:
         self._list = lst
         self._pos = pos
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def category(self) -> str:
         """Accessor for the entry category."""
         return self._list.get_category(self._pos)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def name(self) -> str:
         """Accessor for the entry name."""
         return self._list.get_name(self._pos)
 
     @property
+    @lru_cache(maxsize=None)
     def value(self) -> bytes:
         """Accessor for the entry value."""
         return bytes(self.raw_value)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def raw_value(self) -> memoryview:
         """Accessor for the entry raw value."""
         return self._list.get_value(self._pos)
@@ -57,7 +60,8 @@ class Entry:
         """Accessor for the entry value as JSON."""
         return json.loads(self.value)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def tags(self) -> dict:
         """Accessor for the entry tags."""
         return self._list.get_tags(self._pos)
@@ -147,27 +151,32 @@ class KeyEntry:
         self._list = lst
         self._pos = pos
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def algorithm(self) -> str:
         """Accessor for the key entry algorithm."""
         return self._list.get_algorithm(self._pos)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def name(self) -> str:
         """Accessor for the key entry name."""
         return self._list.get_name(self._pos)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def metadata(self) -> str:
         """Accessor for the key entry metadata."""
         return self._list.get_metadata(self._pos)
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def key(self) -> Key:
         """Accessor for the entry metadata."""
         return Key(self._list.load_key(self._pos))
 
-    @cached_property
+    @property
+    @lru_cache(maxsize=None)
     def tags(self) -> dict:
         """Accessor for the entry tags."""
         return self._list.get_tags(self._pos)

--- a/wrappers/python/requirements.txt
+++ b/wrappers/python/requirements.txt
@@ -1,1 +1,0 @@
-cached_property~=2.0.0


### PR DESCRIPTION
An error could be triggered when the library is loaded from multiple threads simultaneously (for example if a thread pool is used). This update adds a lock around the library initialization.

The `cached_property` dependency is also removed.