### PR TITLE
Fix panic when loading secret keys of invalid length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,11 +147,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -184,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "aries-askar"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "askar-crypto",
  "askar-storage",
@@ -204,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "askar-crypto"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "aead",
  "aes",
@@ -246,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "askar-storage"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arc-swap",
  "askar-crypto",
@@ -399,9 +400,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -496,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -593,18 +594,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -759,9 +760,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-bigint"
@@ -853,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der"
@@ -999,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -1049,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1172,9 +1173,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1251,9 +1252,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "group"
@@ -1517,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1537,13 +1538,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1631,9 +1632,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1662,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -1695,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -1717,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "md-5"
@@ -1745,9 +1746,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1853,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1974,9 +1975,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2088,18 +2089,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2285,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
@@ -2298,9 +2299,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "once_cell",
  "ring",
@@ -2335,6 +2336,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2395,9 +2402,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2405,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
@@ -2767,9 +2774,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2789,12 +2796,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2893,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2908,9 +2916,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2978,9 +2986,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-normalization"
@@ -3044,9 +3052,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
  "getrandom",
 ]
@@ -3087,20 +3095,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -3112,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3122,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3135,15 +3144,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "aries-askar"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2021"
 description = "Hyperledger Aries Askar secure storage"

--- a/askar-crypto/Cargo.toml
+++ b/askar-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askar-crypto"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2021"
 description = "Hyperledger Aries Askar cryptography"

--- a/askar-crypto/src/alg/k256.rs
+++ b/askar-crypto/src/alg/k256.rs
@@ -128,9 +128,8 @@ impl KeyGen for K256KeyPair {
 
 impl KeySecretBytes for K256KeyPair {
     fn from_secret_bytes(key: &[u8]) -> Result<Self, Error> {
-        #[allow(clippy::unnecessary_fallible_conversions)]
-        if let Ok(key) = key.try_into() {
-            if let Ok(sk) = SecretKey::from_bytes(key) {
+        if key.len() == SECRET_KEY_LENGTH {
+            if let Ok(sk) = SecretKey::from_bytes(key.into()) {
                 return Ok(Self::from_secret_key(sk));
             }
         }

--- a/askar-crypto/src/alg/p256.rs
+++ b/askar-crypto/src/alg/p256.rs
@@ -130,9 +130,8 @@ impl KeyGen for P256KeyPair {
 
 impl KeySecretBytes for P256KeyPair {
     fn from_secret_bytes(key: &[u8]) -> Result<Self, Error> {
-        #[allow(clippy::unnecessary_fallible_conversions)]
-        if let Ok(key) = key.try_into() {
-            if let Ok(sk) = SecretKey::from_bytes(key) {
+        if key.len() == SECRET_KEY_LENGTH {
+            if let Ok(sk) = SecretKey::from_bytes(key.into()) {
                 return Ok(Self::from_secret_key(sk));
             }
         }

--- a/askar-crypto/src/alg/p384.rs
+++ b/askar-crypto/src/alg/p384.rs
@@ -1,6 +1,6 @@
 //! Elliptic curve ECDH and ECDSA support on curve secp384r1
 
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 
 use p384::{
     ecdsa::{
@@ -130,9 +130,8 @@ impl KeyGen for P384KeyPair {
 
 impl KeySecretBytes for P384KeyPair {
     fn from_secret_bytes(key: &[u8]) -> Result<Self, Error> {
-        #[allow(clippy::unnecessary_fallible_conversions)]
-        if let Ok(key) = key.try_into() {
-            if let Ok(sk) = SecretKey::from_bytes(key) {
+        if key.len() == SECRET_KEY_LENGTH {
+            if let Ok(sk) = SecretKey::from_bytes(key.into()) {
                 return Ok(Self::from_secret_key(sk));
             }
         }

--- a/askar-crypto/src/buffer/array.rs
+++ b/askar-crypto/src/buffer/array.rs
@@ -200,7 +200,7 @@ struct KeyVisitor<L: ArrayLength<u8>> {
     _pd: PhantomData<L>,
 }
 
-impl<'de, L: ArrayLength<u8>> de::Visitor<'de> for KeyVisitor<L> {
+impl<L: ArrayLength<u8>> de::Visitor<'_> for KeyVisitor<L> {
     type Value = ArrayKey<L>;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {

--- a/askar-crypto/src/buffer/secret.rs
+++ b/askar-crypto/src/buffer/secret.rs
@@ -303,7 +303,7 @@ impl<'de> Deserialize<'de> for SecretBytes {
 
 struct SecVisitor;
 
-impl<'de> de::Visitor<'de> for SecVisitor {
+impl de::Visitor<'_> for SecVisitor {
     type Value = SecretBytes;
 
     fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {

--- a/askar-crypto/src/jwk/encode.rs
+++ b/askar-crypto/src/jwk/encode.rs
@@ -244,7 +244,7 @@ impl<'s, K: ToJwk> JwkSerialize<'s, K> {
     }
 }
 
-impl<'s, K: ToJwk> Serialize for JwkSerialize<'s, K> {
+impl<K: ToJwk> Serialize for JwkSerialize<'_, K> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/askar-storage/Cargo.toml
+++ b/askar-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "askar-storage"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Hyperledger Aries Contributors <aries@lists.hyperledger.org>"]
 edition = "2021"
 description = "Hyperledger Aries Askar secure storage"

--- a/askar-storage/src/backend/db_utils.rs
+++ b/askar-storage/src/backend/db_utils.rs
@@ -243,7 +243,7 @@ impl<DB: ExtDatabase> DbSessionRef<'_, DB> {
     }
 }
 
-impl<'q, DB: ExtDatabase> Deref for DbSessionRef<'q, DB> {
+impl<DB: ExtDatabase> Deref for DbSessionRef<'_, DB> {
     type Target = DbSession<DB>;
 
     fn deref(&self) -> &Self::Target {
@@ -254,7 +254,7 @@ impl<'q, DB: ExtDatabase> Deref for DbSessionRef<'q, DB> {
     }
 }
 
-impl<'q, DB: ExtDatabase> DerefMut for DbSessionRef<'q, DB> {
+impl<DB: ExtDatabase> DerefMut for DbSessionRef<'_, DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Owned(e) => e,
@@ -349,7 +349,7 @@ impl<'a, DB: ExtDatabase> DbSessionTxn<'a, DB> {
     }
 }
 
-impl<'a, DB: ExtDatabase> Drop for DbSessionTxn<'a, DB> {
+impl<DB: ExtDatabase> Drop for DbSessionTxn<'_, DB> {
     fn drop(&mut self) {
         if self.rollback {
             self.inner.txn_depth -= 1;

--- a/askar-storage/src/backend/mod.rs
+++ b/askar-storage/src/backend/mod.rs
@@ -143,7 +143,7 @@ pub trait BackendSession: Debug + Send {
     fn import_scan<'q>(
         &'q mut self,
         mut scan: Scan<'q, Entry>,
-    ) -> BoxFuture<'_, Result<(), Error>> {
+    ) -> BoxFuture<'q, Result<(), Error>> {
         Box::pin(async move {
             while let Some(rows) = scan.fetch_next().await? {
                 for entry in rows {

--- a/askar-storage/src/options.rs
+++ b/askar-storage/src/options.rs
@@ -24,7 +24,7 @@ pub struct Options<'a> {
     pub fragment: Cow<'a, str>,
 }
 
-impl<'a> Options<'a> {
+impl Options<'_> {
     /// Parse a URI string into an Options structure
     pub fn parse_uri(uri: &str) -> Result<Options<'_>, Error> {
         let mut fragment_and_remain = uri.splitn(2, '#');

--- a/askar-storage/src/protect/pass_key.rs
+++ b/askar-storage/src/protect/pass_key.rs
@@ -11,7 +11,7 @@ use std::{
 #[derive(Clone, Default)]
 pub struct PassKey<'a>(Option<Cow<'a, str>>);
 
-impl<'a> PassKey<'a> {
+impl PassKey<'_> {
     /// Create a scoped reference to the passkey
     pub fn as_ref(&self) -> PassKey<'_> {
         PassKey(Some(Cow::Borrowed(&**self)))
@@ -83,8 +83,8 @@ impl<'a> From<Option<&'a str>> for PassKey<'a> {
     }
 }
 
-impl<'a, 'b> PartialEq<PassKey<'b>> for PassKey<'a> {
-    fn eq(&self, other: &PassKey<'b>) -> bool {
+impl<'a> PartialEq<PassKey<'a>> for PassKey<'_> {
+    fn eq(&self, other: &PassKey<'a>) -> bool {
         **self == **other
     }
 }

--- a/src/ffi/tags.rs
+++ b/src/ffi/tags.rs
@@ -149,13 +149,13 @@ impl Serialize for EntryTagSet<'_> {
         #[derive(PartialOrd, Ord)]
         struct TagName<'a>(&'a str, bool);
 
-        impl<'a> PartialEq for TagName<'a> {
+        impl PartialEq for TagName<'_> {
             fn eq(&self, other: &Self) -> bool {
                 self.1 == other.1 && self.0 == other.0
             }
         }
 
-        impl<'a> Eq for TagName<'a> {}
+        impl Eq for TagName<'_> {}
 
         impl Serialize for TagName<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/kms/enc.rs
+++ b/src/kms/enc.rs
@@ -59,7 +59,7 @@ pub struct ToDecrypt<'d> {
     pub tag: &'d [u8],
 }
 
-impl<'d> ToDecrypt<'d> {
+impl ToDecrypt<'_> {
     /// Accessor for the combined length
     #[allow(clippy::len_without_is_empty)]
     #[inline]

--- a/wrappers/python/aries_askar/version.py
+++ b/wrappers/python/aries_askar/version.py
@@ -1,3 +1,3 @@
 """aries_askar library wrapper version."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
This fix affects the loading of k256, p256, and p384 secret keys. If a key of the wrong length was passed then a panic would occur rather than returning an error.

Also fixes a few clippy warnings and updates the package versions for a new release.