### PR TITLE
Python wrapper entry cache adjustment

### DIFF
--- a/wrappers/python/aries_askar/bindings/handle.py
+++ b/wrappers/python/aries_askar/bindings/handle.py
@@ -18,7 +18,7 @@ from ctypes import (
     c_void_p,
 )
 
-from .lib import ByteBuffer, Lib, StrBuffer, finalize_struct
+from .lib import ByteBuffer, Lib, StrBuffer, entry_cache, finalize_struct
 
 
 LOGGER = logging.getLogger(__name__)
@@ -124,6 +124,7 @@ class EntryListHandle(ArcHandle):
 
     _dtor_ = "askar_entry_list_free"
 
+    @entry_cache
     def get_category(self, index: int) -> str:
         """Get the entry category."""
         cat = StrBuffer()
@@ -136,6 +137,7 @@ class EntryListHandle(ArcHandle):
         )
         return str(cat)
 
+    @entry_cache
     def get_name(self, index: int) -> str:
         """Get the entry name."""
         name = StrBuffer()
@@ -148,6 +150,7 @@ class EntryListHandle(ArcHandle):
         )
         return str(name)
 
+    @entry_cache
     def get_value(self, index: int) -> memoryview:
         """Get the entry value."""
         val = ByteBuffer()
@@ -160,6 +163,7 @@ class EntryListHandle(ArcHandle):
         )
         return val.view
 
+    @entry_cache
     def get_tags(self, index: int) -> dict:
         """Get the entry tags."""
         tags = StrBuffer()
@@ -185,6 +189,7 @@ class KeyEntryListHandle(ArcHandle):
 
     _dtor_ = "askar_key_entry_list_free"
 
+    @entry_cache
     def get_algorithm(self, index: int) -> str:
         """Get the key algorithm."""
         name = StrBuffer()
@@ -197,6 +202,7 @@ class KeyEntryListHandle(ArcHandle):
         )
         return str(name)
 
+    @entry_cache
     def get_name(self, index: int) -> str:
         """Get the key name."""
         name = StrBuffer()
@@ -209,6 +215,7 @@ class KeyEntryListHandle(ArcHandle):
         )
         return str(name)
 
+    @entry_cache
     def get_metadata(self, index: int) -> str:
         """Get for the key metadata."""
         metadata = StrBuffer()
@@ -221,6 +228,7 @@ class KeyEntryListHandle(ArcHandle):
         )
         return str(metadata)
 
+    @entry_cache
     def get_tags(self, index: int) -> dict:
         """Get the key tags."""
         tags = StrBuffer()

--- a/wrappers/python/aries_askar/bindings/lib.py
+++ b/wrappers/python/aries_askar/bindings/lib.py
@@ -8,6 +8,7 @@ import os
 import sys
 import threading
 import time
+from copy import deepcopy
 
 try:
     import orjson as json
@@ -59,12 +60,13 @@ def entry_cache(fn):
         cache = self._ecache
         ckey = (fn, index)
         if ckey in cache:
-            return cache[ckey]
-        res = fn(self, index)
-        cache[ckey] = res
+            res = cache[ckey]
+        else:
+            res = fn(self, index)
+            cache[ckey] = res
         if isinstance(res, dict):
             # make sure the cached copy is not mutated
-            res = dict(res)
+            res = deepcopy(res)
         return res
 
     return wrapper

--- a/wrappers/python/aries_askar/store.py
+++ b/wrappers/python/aries_askar/store.py
@@ -5,7 +5,6 @@ try:
 except ImportError:
     import json
 
-from functools import lru_cache
 from typing import Optional, Sequence, Union
 
 from . import bindings
@@ -32,25 +31,21 @@ class Entry:
         self._pos = pos
 
     @property
-    @lru_cache(maxsize=None)
     def category(self) -> str:
         """Accessor for the entry category."""
         return self._list.get_category(self._pos)
 
     @property
-    @lru_cache(maxsize=None)
     def name(self) -> str:
         """Accessor for the entry name."""
         return self._list.get_name(self._pos)
 
     @property
-    @lru_cache(maxsize=None)
     def value(self) -> bytes:
         """Accessor for the entry value."""
         return bytes(self.raw_value)
 
     @property
-    @lru_cache(maxsize=None)
     def raw_value(self) -> memoryview:
         """Accessor for the entry raw value."""
         return self._list.get_value(self._pos)
@@ -61,7 +56,6 @@ class Entry:
         return json.loads(self.value)
 
     @property
-    @lru_cache(maxsize=None)
     def tags(self) -> dict:
         """Accessor for the entry tags."""
         return self._list.get_tags(self._pos)
@@ -152,31 +146,26 @@ class KeyEntry:
         self._pos = pos
 
     @property
-    @lru_cache(maxsize=None)
     def algorithm(self) -> str:
         """Accessor for the key entry algorithm."""
         return self._list.get_algorithm(self._pos)
 
     @property
-    @lru_cache(maxsize=None)
     def name(self) -> str:
         """Accessor for the key entry name."""
         return self._list.get_name(self._pos)
 
     @property
-    @lru_cache(maxsize=None)
     def metadata(self) -> str:
         """Accessor for the key entry metadata."""
         return self._list.get_metadata(self._pos)
 
     @property
-    @lru_cache(maxsize=None)
     def key(self) -> Key:
-        """Accessor for the entry metadata."""
+        """Accessor for the key instance."""
         return Key(self._list.load_key(self._pos))
 
     @property
-    @lru_cache(maxsize=None)
     def tags(self) -> dict:
         """Accessor for the entry tags."""
         return self._list.get_tags(self._pos)

--- a/wrappers/python/setup.cfg
+++ b/wrappers/python/setup.cfg
@@ -10,4 +10,5 @@ per_file_ignores = */__init__.py:D104
 minversion = 5.0
 testpaths =
     tests
-asyncio_mode=strict
+asyncio_mode=auto
+asyncio_default_fixture_loop_scope=session


### PR DESCRIPTION
From the Python library documentation it appears that the native `lru_cache` decorator could result in caching of Entry instances longer than necessary. This PR switches to a custom cache implementation at the EntryList level which should avoid any undesired behaviour.

@ff137