### PR TITLE
Add support for prehashed signatures on EC curves

### DIFF
--- a/askar-crypto/src/alg/k256.rs
+++ b/askar-crypto/src/alg/k256.rs
@@ -2,7 +2,10 @@
 
 use k256::{
     ecdsa::{
-        signature::{Signer, Verifier},
+        signature::{
+            hazmat::{PrehashSigner, PrehashVerifier},
+            Signer, Verifier,
+        },
         Signature, SigningKey, VerifyingKey,
     },
     elliptic_curve::{
@@ -92,11 +95,32 @@ impl K256KeyPair {
         }
     }
 
-    /// Verify a signature with the public key
+    /// Sign a pre-hashed message with the secret key
+    pub fn sign_prehashed(&self, hashed_message: &[u8]) -> Option<[u8; ES256K_SIGNATURE_LENGTH]> {
+        if let Some(skey) = self.to_signing_key() {
+            if let Ok(sig) = PrehashSigner::<Signature>::sign_prehash(&skey, hashed_message) {
+                let sigb: [u8; 64] = sig.to_bytes().into();
+                return Some(sigb);
+            }
+        }
+        None
+    }
+
+    /// Verify a signature against the public key
     pub fn verify_signature(&self, message: &[u8], signature: &[u8]) -> bool {
         if let Ok(sig) = Signature::try_from(signature) {
             let vk = VerifyingKey::from(&self.public);
             vk.verify(message, &sig).is_ok()
+        } else {
+            false
+        }
+    }
+
+    /// Verify a signature on a prehashed message against the public key
+    pub fn verify_signature_prehashed(&self, hashed_message: &[u8], signature: &[u8]) -> bool {
+        if let Ok(sig) = Signature::try_from(signature) {
+            let vk = VerifyingKey::from(&self.public);
+            vk.verify_prehash(hashed_message, &sig).is_ok()
         } else {
             false
         }
@@ -205,7 +229,15 @@ impl KeySign for K256KeyPair {
                     out.buffer_write(&sig[..])?;
                     Ok(())
                 } else {
-                    Err(err_msg!(Unsupported, "Undefined secret key"))
+                    Err(err_msg!(Unsupported, "Signing operation not supported"))
+                }
+            }
+            Some(SignatureType::ES256Kph) => {
+                if let Some(sig) = self.sign_prehashed(message) {
+                    out.buffer_write(&sig[..])?;
+                    Ok(())
+                } else {
+                    Err(err_msg!(Unsupported, "Signing operation not supported"))
                 }
             }
             #[allow(unreachable_patterns)]
@@ -223,6 +255,9 @@ impl KeySigVerify for K256KeyPair {
     ) -> Result<bool, Error> {
         match sig_type {
             None | Some(SignatureType::ES256K) => Ok(self.verify_signature(message, signature)),
+            Some(SignatureType::ES256Kph) => {
+                Ok(self.verify_signature_prehashed(message, signature))
+            }
             #[allow(unreachable_patterns)]
             _ => Err(err_msg!(Unsupported, "Unsupported signature type")),
         }
@@ -324,6 +359,7 @@ impl KeyExchange for K256KeyPair {
 #[cfg(test)]
 mod tests {
     use base64::Engine;
+    use sha2::Digest;
 
     use super::*;
     use crate::repr::ToPublicBytes;
@@ -389,6 +425,24 @@ mod tests {
         assert!(kp.verify_signature(&test_msg[..], &sig[..]));
         assert!(!kp.verify_signature(b"Not the message", &sig[..]));
         assert!(!kp.verify_signature(&test_msg[..], &[0u8; 64]));
+    }
+
+    #[test]
+    fn sign_verify_expected_prehash() {
+        let test_msg = sha2::Sha256::digest(b"This is a dummy message for use with tests");
+        let test_sig = &hex!(
+            "a2a3affbe18cda8c5a7b6375f05b304c2303ab8beb21428709a43a519f8f946f
+            6ffa7966afdb337e9b1f70bb575282e71d4fe5bbe6bfa97b229d6bd7e97df1e5"
+        );
+        let test_pvt = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode("jv_VrhPomm6_WOzb74xF4eMI0hu9p0W1Zlxi0nz8AFs")
+            .unwrap();
+        let kp = K256KeyPair::from_secret_bytes(&test_pvt).unwrap();
+        let sig = kp.sign_prehashed(&test_msg[..]).unwrap();
+        assert_eq!(sig, &test_sig[..]);
+        assert!(kp.verify_signature_prehashed(&test_msg[..], &sig[..]));
+        assert!(!kp.verify_signature_prehashed(b"Not the message", &sig[..]));
+        assert!(!kp.verify_signature_prehashed(&test_msg[..], &[0u8; 64]));
     }
 
     #[test]

--- a/askar-crypto/src/sign.rs
+++ b/askar-crypto/src/sign.rs
@@ -51,10 +51,16 @@ pub enum SignatureType {
     EdDSA,
     /// Elliptic curve DSA using P-256 and SHA-256
     ES256,
+    /// Elliptic curve DSA using P-256 and pre-hashed input
+    ES256ph,
     /// Elliptic curve DSA using K-256 and SHA-256
     ES256K,
+    /// Elliptic curve DSA using K-256 and pre-hashed input
+    ES256Kph,
     /// Elliptic curve DSA using P-384 and SHA-384
     ES384,
+    /// Elliptic curve DSA using P-384 and pre-hashed input
+    ES384ph,
 }
 
 impl FromStr for SignatureType {
@@ -64,8 +70,11 @@ impl FromStr for SignatureType {
         match normalize_alg(s)? {
             a if a == "eddsa" => Ok(Self::EdDSA),
             a if a == "es256" => Ok(Self::ES256),
+            a if a == "es256ph" => Ok(Self::ES256ph),
             a if a == "es256k" => Ok(Self::ES256K),
+            a if a == "es256kph" => Ok(Self::ES256Kph),
             a if a == "es384" => Ok(Self::ES384),
+            a if a == "es384ph" => Ok(Self::ES384ph),
             _ => Err(err_msg!(Unsupported, "Unknown signature algorithm")),
         }
     }
@@ -75,8 +84,8 @@ impl SignatureType {
     /// Get the length of the signature output.
     pub const fn signature_length(&self) -> usize {
         match self {
-            Self::EdDSA | Self::ES256 | Self::ES256K => 64,
-            Self::ES384 => 96,
+            Self::EdDSA | Self::ES256 | Self::ES256ph | Self::ES256K | Self::ES256Kph => 64,
+            Self::ES384 | Self::ES384ph => 96,
         }
     }
 }

--- a/src/ffi/store.rs
+++ b/src/ffi/store.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, ffi::CString, os::raw::c_char, ptr, str::FromStr, sync::Arc};
 
-use askar_storage::backend::{copy_profile, OrderBy};
+use askar_storage::backend::OrderBy;
 use async_lock::{Mutex as TryMutex, MutexGuardArc as TryMutexGuard, RwLock};
 use ffi_support::{rust_string_to_c, ByteBuffer, FfiStr};
 use once_cell::sync::Lazy;
@@ -555,7 +555,7 @@ pub extern "C" fn askar_store_copy_profile(
             let result = async move {
                 let from_store = from_handle.load().await?;
                 let to_store = to_handle.load().await?;
-                copy_profile(from_store.backend(), to_store.backend(), &from_profile, &to_profile).await?;
+                from_store.copy_profile_to(&to_store, &from_profile, &to_profile).await?;
                 debug!("Copied profile {}/{} to {}/{}", from_handle, from_profile, to_handle, to_profile);
                 Ok(())
             }.await;

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,10 +22,6 @@ impl Store {
         Self(inner)
     }
 
-    pub(crate) fn backend(&self) -> &AnyBackend {
-        &self.0
-    }
-
     /// Provision a new store instance using a database URL
     pub async fn provision(
         db_url: &str,
@@ -102,6 +98,17 @@ impl Store {
             copy_profile(&self.0, &target, &profile, &profile).await?;
         }
         Ok(Self::new(target))
+    }
+
+    /// Copy to a new store instance using a database URL
+    pub async fn copy_profile_to(
+        &self,
+        target: &Store,
+        from_name: &str,
+        to_name: &str,
+    ) -> Result<(), Error> {
+        copy_profile(&self.0, &target.0, from_name, to_name).await?;
+        Ok(())
     }
 
     /// Create a new profile with the given profile name

--- a/wrappers/python/tests/test_keys.py
+++ b/wrappers/python/tests/test_keys.py
@@ -1,6 +1,6 @@
 import json
+import hashlib
 
-from aries_askar.types import KeyBackend
 import pytest
 
 from aries_askar import (
@@ -8,6 +8,7 @@ from aries_askar import (
     Key,
     SeedMethod,
 )
+from aries_askar.types import KeyBackend
 
 
 def test_get_supported_backends():
@@ -106,3 +107,10 @@ def test_ec_curves(key_alg: KeyAlg):
     assert jwk["x"]
     assert jwk["y"]
     assert jwk["d"]
+
+
+def test_sign_prehashed():
+    key = Key.generate("p256")
+    message = hashlib.sha384(b"test message").digest()
+    sig = key.sign_message(message, "es256ph")
+    assert key.verify_signature(message, sig, "es256ph")


### PR DESCRIPTION
This adds support for three new (non-JWA) signing algorithms accepting pre-hashed input. The input may be larger or smaller than the field size, allowing mixing of (for example) a SHA-384 hash with a P-256 signing key.

Fixes #371 